### PR TITLE
Updated hyperlinks to reflect repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject={project_name}). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=SMCQL%20Experiment). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Firstly, we would like to thank you for taking the time to contribute!
 
-The following is a set of guidelines for contributing to {project_name} and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to SMCQL Experiment and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
 
@@ -27,7 +27,7 @@ The following is a set of guidelines for contributing to {project_name} and its 
 
 ## Code of Conduct
 
-This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject={project_name}).
+This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=SMCQL%20Experiment).
 
 ## FAQs
 
@@ -37,19 +37,19 @@ We don't have any frequently asked questions yet.
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for {project_module_name}. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for smcql-experiment. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
 
-Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/{project_module_name}/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/smcql-experiment/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
 #### Before Submitting A Bug Report
 
-- **Perform a [cursory search](https://github.com/search?q=+is%3Aissue+user%3A{project_module_name})** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+- **Perform a [cursory search](https://github.com/search?q=+is%3Aissue+user%3Asmcql-experiment)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on that repository and provide the following information by filling in [the template](https://github.com/digicatapult/{project_module_name}/.github/blob/main/.github/ISSUE_TEMPLATE/bug_report.md).
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on that repository and provide the following information by filling in [the template](https://github.com/digicatapult/smcql-experiment/.github/blob/main/.github/ISSUE_TEMPLATE/bug_report.md).
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -59,30 +59,30 @@ Explain the problem and include additional details to help maintainers reproduce
 - **Describe the behaviour you observed after following the steps** and point out what exactly is the problem with that behaviour.
 - **Explain which behaviour you expected to see instead and why.**
 - **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. If you use the keyboard while following the steps, \*\*record the GIF with the [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/Xaviju/byzanzUI) on Linux.
-- **If you're reporting that {project_module_name} crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
+- **If you're reporting that smcql-experiment crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
 - **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
-- **Did the problem start happening recently** (e.g. after updating to a new version of {project_module_name}) or was this always a problem?
-- If the problem started happening recently, **can you reproduce the problem in an older version of {project_module_name}?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of {project_module_name} from [the releases page](https://github.com/digicatapult/{project_module_name}/releases).
+- **Did the problem start happening recently** (e.g. after updating to a new version of smcql-experiment) or was this always a problem?
+- If the problem started happening recently, **can you reproduce the problem in an older version of smcql-experiment?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of smcql-experiment from [the releases page](https://github.com/digicatapult/smcql-experiment/releases).
 - **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 Include details about your configuration and environment:
 
-- **Which version of {project_module_name} are you using?** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed {project_module_name} to**?
-- **Are you running {project_module_name} in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
+- **Which version of smcql-experiment are you using?** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed smcql-experiment to**?
+- **Are you running smcql-experiment in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for {project_module_name}, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for smcql-experiment, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
-Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/{project_module_name}/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
+Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/smcql-experiment/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
 #### Before Submitting An Enhancement Suggestion
 
-- **Perform a [cursory search](https://github.com/search?q=+is%3Aissue+user%3A{project_module_name})** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- **Perform a [cursory search](https://github.com/search?q=+is%3Aissue+user%3Asmcql-experiment)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
@@ -92,19 +92,19 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 - **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 - **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 - **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why.
-- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of {project_module_name} which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-- **Explain why this enhancement would be useful** to most {project_module_name} users.
+- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of smcql-experiment which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most smcql-experiment users.
 - **List some other text editors or applications where this enhancement exists.**
-- **Specify which version of {project_module_name} you're using.** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed {project_module_name} to**?
+- **Specify which version of smcql-experiment you're using.** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed smcql-experiment to**?
 
 ### Pull Requests
 
 The process described here has several goals:
 
-- Maintain {project_module_name}'s quality
+- Maintain smcql-experiment's quality
 - Fix problems that are important to users
-- Enable a sustainable system for {project_module_name}'s maintainers to review contributions
+- Enable a sustainable system for smcql-experiment's maintainers to review contributions
 
 Please follow these steps to have your contribution considered by the maintainers:
 


### PR DESCRIPTION
The open-source guidelines have been updated from their placeholders to reflect the correct repo.
